### PR TITLE
Don't require variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ npm install --save-dev browserify-compile-templates
 ## Create a template file
 myTemplates.html
 
-Use the ID attribute to identify the template from your JS source.
-Use data-variable-name to change the variable name that is used in the underscore template. obj is the default
+Use the `id` attribute to identify the template from your JS source.
+Use data-variable-name to change the variable name that is used in the underscore template. `obj` is the default
 
 ```html
 <script type="text/template" id="template1">
@@ -28,6 +28,8 @@ Use data-variable-name to change the variable name that is used in the underscor
 	<li><%- data.name %> <<%- data.email %>></li>
 </script>
 ```
+
+Alternatively, if you do not want to scope your template values under a variable, provide the `{ noVar: true }` option to the transform. **Note:** This will affect the compilation of ___all___ your templates!
 
 ## Require the template file
 A JS file

--- a/index.js
+++ b/index.js
@@ -6,11 +6,10 @@ module.exports = transformTools.makeStringTransform('compile-templates', {}, fun
     var file = transformOptions.file;
     var output;
     var extension = path.extname(file);
-    var config = transformOptions.configData;
-    config = config && config.config;
+    var options = transformOptions.opts;
 
     if (extension === '.html') {
-        output = compileFile(content, config);
+        output = compileFile(content, options);
         // If compileFile returned an error send that to done
         if (output instanceof Error) {
             done(output.message);

--- a/index.js
+++ b/index.js
@@ -6,8 +6,11 @@ module.exports = transformTools.makeStringTransform('compile-templates', {}, fun
     var file = transformOptions.file;
     var output;
     var extension = path.extname(file);
+    var config = transformOptions.configData;
+    config = config && config.config;
+
     if (extension === '.html') {
-        output = compileFile(content);
+        output = compileFile(content, config);
         // If compileFile returned an error send that to done
         if (output instanceof Error) {
             done(output.message);

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -22,7 +22,7 @@ module.exports = function (html, options) {
                 var id = el.attribs.id;
                 var compiled;
                 var varName = el.attribs['data-variable-name'] || 'obj';
-                if (options && options.useWith) {
+                if (options && options.noVar) {
                     varName = null;
                 }
                 try {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -3,7 +3,7 @@
 var htmlparser = require('htmlparser2');
 var _ = require('underscore');
 
-module.exports = function (html, config) {
+module.exports = function (html, options) {
     var output = '';
     var templateCount = 0;
     var err = false;
@@ -22,7 +22,7 @@ module.exports = function (html, config) {
                 var id = el.attribs.id;
                 var compiled;
                 var varName = el.attribs['data-variable-name'] || 'obj';
-                if (config && config.useWith) {
+                if (options && options.useWith) {
                     varName = null;
                 }
                 try {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -3,7 +3,7 @@
 var htmlparser = require('htmlparser2');
 var _ = require('underscore');
 
-module.exports = function (html) {
+module.exports = function (html, config) {
     var output = '';
     var templateCount = 0;
     var err = false;
@@ -22,6 +22,9 @@ module.exports = function (html) {
                 var id = el.attribs.id;
                 var compiled;
                 var varName = el.attribs['data-variable-name'] || 'obj';
+                if (config && config.useWith) {
+                    varName = null;
+                }
                 try {
                     compiled = _.template(templateString, null, {variable: varName});
                     compiled = '    "' + id + '": ' + compiled.source;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-compile-templates",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Compiles templates from HTML script tags into CommonJS modules in a browserify transform",
   "main": "index.js",
   "homepage": "https://github.com/robrichard/browserify-compile-templates",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "underscore": "^1.6.0",
     "htmlparser2": "~3.7.1",
-    "browserify-transform-tools": "^1.2.1"
+    "browserify-transform-tools": "^1.3.0"
   },
   "keywords": [
     "template",


### PR DESCRIPTION
Underscore templates [render faster](http://underscorejs.org/#template) when the values referenced in the template are explicitly attached to an object. However, the default behavior for `_.template` is to place the values from the provided data into the local scope using the `with` statement. Subsequently, many templates in the wild use this method (example template: `_.template("<%= value %>")`) over the variable namespace method (example: `_.template("<%= obj.value %>")`), despite the (often negligible) performance cost. The `browserify-compile-templates` transform only supports the variable namespace method, and subsequently places a burden on developers more familiar with the default method (or with pre-existing templates written in the default method) to revise their style and templates.

This update gives the transform the ability to support the default method. To make use of this feature, the developer must provide the `{ noVar: true }` parameter to the transform.

Bumped the version number to 0.2.0, and also updated the dependency on `browserify-transform-tools` to 1.3.0, as the changes here depend on changes I made to that repo as well.
