### PR TITLE
No scope pollution

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -10,7 +10,7 @@ module.exports = function (html, options) {
     var compiledTemplates = [];
 
     var writeOutput = new htmlparser.DomHandler(function (error, dom) {
-        output += "_ = require('underscore');\n";
+        output += "var _ = require('underscore');\n";
         output += 'module.exports = {\n';
         _.each(dom, function (el) {
             if (el.children &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-compile-templates",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Compiles templates from HTML script tags into CommonJS modules in a browserify transform",
   "main": "index.js",
   "homepage": "https://github.com/robrichard/browserify-compile-templates",


### PR DESCRIPTION
Adds the `var` keyword to the `_` declaration in the compiled template. This prevents underscore from seeping into the global namespace.

See #3 
